### PR TITLE
Modified .bashrc and .zshrc to comment out the call to iterm2 shell

### DIFF
--- a/home/.bashrc
+++ b/home/.bashrc
@@ -329,7 +329,7 @@ ihighlight () {
 }
 
 # iTerm2 / 3 Shell Integration
-test -e ${HOME}/.iterm2_shell_integration.bash && source ${HOME}/.iterm2_shell_integration.bash
+#test -e ${HOME}/.iterm2_shell_integration.bash && source ${HOME}/.iterm2_shell_integration.bash
 
 # Git Stuff
 # Don't use the pager for 'git diff', i.e. dump it all out to the terminal at once

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -307,7 +307,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
 fi
 
 # iTerm2 Shell Integration
-test -e ${HOME}/.iterm2_shell_integration.zsh && source ${HOME}/.iterm2_shell_integration.zsh
+#test -e ${HOME}/.iterm2_shell_integration.zsh && source ${HOME}/.iterm2_shell_integration.zsh
 
 # Git Stuff
 # Don't use the pager for 'git diff', i.e. dump it all out to the terminal at once


### PR DESCRIPTION
integration. Unfortunately this causes a messy looking shell when using
a terminal other than iTerm2, example gnome-terminal or guake

See: https://gitlab.com/gnachman/iterm2/issues/4743
The iTerm2 author provides a workaround that uses a call to a helper
script that returns iterm if using iTerm2:

`isiterm2.sh && echo is iterm || echo is gnome terminal`

Implementation is as follows:
`${HOME}/isiterm2.sh && test -e "${HOME}/.iterm2_shell_integration.zsh"
&& source "${HOME}/.iterm2_shell_integration.zsh"`

* Changes to be committed:
  * modified:   home/.bashrc
  * modified:   home/.zshrc