### PR TITLE
Added iterm2 conditional check to .zshrc and .bashrc to prevent sourcing

### DIFF
--- a/home/.bashrc
+++ b/home/.bashrc
@@ -330,6 +330,7 @@ ihighlight () {
 
 # iTerm2 / 3 Shell Integration
 #test -e ${HOME}/.iterm2_shell_integration.bash && source ${HOME}/.iterm2_shell_integration.bash
+${HOME}/isiterm2.sh && test -e "${HOME}/.iterm2_shell_integration.bash" && source "${HOME}/.iterm2_shell_integration.bash"
 
 # Git Stuff
 # Don't use the pager for 'git diff', i.e. dump it all out to the terminal at once

--- a/home/.iterm2_shell_integration.zsh
+++ b/home/.iterm2_shell_integration.zsh
@@ -1,6 +1,6 @@
-if [[ -o login ]]; then
+if [[ -o interactive ]]; then
   if [ "$TERM" != "screen" -a "$ITERM_SHELL_INTEGRATION_INSTALLED" = "" ]; then
-    export ITERM_SHELL_INTEGRATION_INSTALLED=Yes
+    ITERM_SHELL_INTEGRATION_INSTALLED=Yes
     ITERM2_SHOULD_DECORATE_PROMPT="1"
     # Indicates start of command output. Runs just before command executes.
     iterm2_before_cmd_executes() {
@@ -8,7 +8,7 @@ if [[ -o login ]]; then
     }
 
     iterm2_set_user_var() {
-      printf "\033]1337;SetUserVar=%s=%s\007" "$1" $(printf "%s" "$2" | base64)
+      printf "\033]1337;SetUserVar=%s=%s\007" "$1" $(printf "%s" "$2" | base64 | tr -d '\n')
     }
 
     # Users can write their own version of this method. It should call
@@ -35,7 +35,7 @@ if [[ -o login ]]; then
     }
 
     # Mark start of prompt
-    iterm2_prompt_start() {
+    iterm2_prompt_mark() {
       printf "\033]133;A\007"
     }
 
@@ -89,7 +89,12 @@ if [[ -o login ]]; then
       ITERM2_SHOULD_DECORATE_PROMPT=""
 
       # Add our escape sequences just before the prompt is shown.
-      PS1="%{$(iterm2_prompt_start)%}$PS1%{$(iterm2_prompt_end)%}"
+      if [[ $PS1 == *'$(iterm2_prompt_mark)'* ]]
+      then
+        PS1="$PS1%{$(iterm2_prompt_end)%}"
+      else
+        PS1="%{$(iterm2_prompt_mark)%}$PS1%{$(iterm2_prompt_end)%}"
+      fi
     }
 
     iterm2_precmd() {
@@ -124,7 +129,7 @@ if [[ -o login ]]; then
     preexec_functions=($preexec_functions iterm2_preexec)
 
     iterm2_print_state_data
-    printf "\033]1337;ShellIntegrationVersion=2;shell=zsh\007"
+    printf "\033]1337;ShellIntegrationVersion=5;shell=zsh\007"
   fi
 fi
-alias imgcat=~/.iterm2/imgcat; alias it2dl=~/.iterm2/it2dl
+alias imgcat=~/.iterm2/imgcat;alias imgls=~/.iterm2/imgls;alias it2attention=~/.iterm2/it2attention;alias it2check=~/.iterm2/it2check;alias it2copy=~/.iterm2/it2copy;alias it2dl=~/.iterm2/it2dl;alias it2getvar=~/.iterm2/it2getvar;alias it2setcolor=~/.iterm2/it2setcolor;alias it2setkeylabel=~/.iterm2/it2setkeylabel;alias it2ul=~/.iterm2/it2ul;alias it2universion=~/.iterm2/it2universion

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -308,6 +308,7 @@ fi
 
 # iTerm2 Shell Integration
 #test -e ${HOME}/.iterm2_shell_integration.zsh && source ${HOME}/.iterm2_shell_integration.zsh
+${HOME}/isiterm2.sh && test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell_integration.zsh"
 
 # Git Stuff
 # Don't use the pager for 'git diff', i.e. dump it all out to the terminal at once

--- a/home/isiterm2.sh
+++ b/home/isiterm2.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Make sure stdin and stdout are a tty.
+if [ ! -t 0 ] ; then
+  exit 1
+fi
+if [ ! -t 1 ] ; then
+  exit 1
+fi
+
+# Save the tty's state.
+saved_stty=$(stty -g)
+
+# Trap ^C to fix the tty.
+trap ctrl_c INT
+
+function ctrl_c() {
+  stty "$saved_stty"
+  exit 1
+}
+
+# Read some bytes from stdin. Pass the number of bytes to read as the first argument.
+function read_bytes()
+{
+  numbytes=$1
+  dd bs=1 count=$numbytes 2>/dev/null
+}
+
+function read_dsr() {
+  # Reading response to DSR.
+  dsr=""
+  spam=$(read_bytes 2)
+  byte=$(read_bytes 1)
+  while [ "${byte}" != "n" ]; do
+    dsr=${dsr}${byte}
+    byte=$(read_bytes 1)
+  done
+  echo ${dsr}
+}
+
+# Extract the terminal name from DSR 1337
+function terminal {
+  echo -n "$1" | sed -e 's/ .*//'
+}
+
+# Extract the version number from DSR 1337
+function version {
+  echo -n "$1" | sed -e 's/.* //'
+}
+
+# Enter raw mode and turn off echo so the terminal and I can chat quietly.
+stty -echo -icanon raw
+
+# Support for the extension first appears in this version of iTerm2:
+MIN_VERSION=2.9.20160304
+if [ $# -eq 1 ]; then
+  MIN_VERSION=$1
+fi
+
+# Send iTerm2-proprietary code. Other terminals ought to ignore it (but are
+# free to use it respectfully).  The response won't start with a 0 so we can
+# distinguish it from the response to DSR 5. It should contain the terminal's
+# name followed by a space followed by its version number and be terminated
+# with an n.
+echo -n '[1337n'
+
+# Report device status. Responds with esc [ 0 n. All terminals support this. We
+# do this because if the terminal will not respond to iTerm2's custom escape
+# sequence, we can still read from stdin without blocking indefinitely.
+echo -n '[5n'
+
+version_string=$(read_dsr)
+if [ "${version_string}" != "0" -a "${version_string}" != "3" ]; then
+  # Already read DSR 1337. Read DSR 5 and throw it away.
+  dsr=$(read_dsr)
+else
+  # Terminal didn't respond to the DSR 1337. The response we read is from DSR 5.
+  version_string=""
+fi
+
+# Restore the terminal to cooked mode.
+stty "$saved_stty"
+
+# Extract the terminal name and version number from the response.
+version=$(version "${version_string}")
+term=$(terminal "${version_string}")
+
+# Check if they match what we're looking for. This becomes the return code of the script.
+test "$term" = ITERM2 -a \( "$version" \> "$MIN_VERSION" -o "$version" = "$MIN_VERSION" \)


### PR DESCRIPTION
iTerm2 configuration file when not using iTerm2

See: https://gitlab.com/gnachman/iterm2/issues/4743
The iTerm2 author provides a workaround that uses a call to a helper
script that returns iterm if using iTerm2:

`isiterm2.sh && echo is iterm || echo is gnome terminal`

Implementation is as follows:
`${HOME}/isiterm2.sh && test -e "${HOME}/.iterm2_shell_integration.zsh"
&& source "${HOME}/.iterm2_shell_integration.zsh"`

`isiterm2.sh` source: https://raw.githubusercontent.com/gnachman/iTerm2/master/tests/isiterm2.sh

* Changes to be committed:
  *	modified:   home/.bashrc
  *	modified:   home/.iterm2_shell_integration.zsh
  *	modified:   home/.zshrc
  *	new file:   home/isiterm2.sh