### PR TITLE
Combined the left and right prompts into a single left prompt for the

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ TODO: Turn this into an Ansible playbook
 
 ```shell
 # Install zsh and other helper apps if not already installed
-sudo yum -y install zsh unzip wget curl
+sudo yum -y install zsh unzip wget curl git
 
 # Install Oh-my-zsh (http://ohmyz.sh/)
 sh -c "$(curl -fsSL https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -5,6 +5,11 @@ export POWERLEVEL9K_MODE='awesome-fontconfig'
 
 # Disable the right prompt, sucks for copy and paste into tickets
 export POWERLEVEL9K_DISABLE_RPROMPT=true
+# Default Left and Right prompts, I'm combining them bc I routinely copy and paste from the
+# command line into notes / support tickets and the RPROMT doesn't paste well
+#         POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context dir vcs)
+#         POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(status root_indicator background_jobs history time)
+export POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(root_indicator context history time dir vcs status)
 
 export TERM="xterm-256color"
 


### PR DESCRIPTION
PowerLevel9k theme.

Default Left and Right prompts:
   -  `POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context dir vcs)`
   -  `POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(status root_indicator background_jobs history time)`

Combined both to the left:
   -  `POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(root_indicator context history time dir vcs status)`

On branch move-rprompt-to-left

-  Changes to be committed:
   -	modified:   README.md
   -	modified:   home/.zshrc