### PR TITLE
Fixed plugin loading syntax error in zshrc

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -71,9 +71,7 @@ HIST_STAMPS="yyyy-mm-dd"
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(git)
-plugins=(zsh-autosuggestions)
-plugins=(zsh-syntax-highlighting)
+plugins=(git zsh-autosuggestions zsh-syntax-highlighting)
 
 # User configuration
 # export MANPATH="/usr/local/man:$MANPATH"


### PR DESCRIPTION
Loading all plugins in a single call
`plugins=(git zsh-autosuggestions zsh-syntax-highlighting)`

On branch fix-plugin-loading-zshrc

- Changes to be committed:
  -	modified:   home/.zshrc