### PR TITLE
Updated .zshrc zshaddhistory() pattern

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -110,7 +110,7 @@ setopt interactivecomments
 #   or a space, ^ , etc... by overriding builting func zshaddhistory()
 function zshaddhistory() {
   emulate -L zsh
-  if ! [[ "$1" =~ "(^#|^ |^ykchalresp|--password)" ]] ; then
+  if ! [[ "$1" =~ "(^#\s+|^\s+#|^ |^ykchalresp|--password)" ]] ; then
       print -sr -- "${1%%$'\n'}"
       fc -p
   else


### PR DESCRIPTION
https://stackoverflow.com/a/59649474/1361782

`if ! [[ "$1" =~ "(^#\s+|^\s+#|^ |^ykchalresp|--password)" ]] ; then`

- Will log comments that start in column 1 not followed by one or more spaces (i.e. #somecommand that I want to come back to)
- Won't log comments that start in column 1 followed by one or more spaces
- Won't log indented comments, padded by spaces from column 1
- Won't log commands with a space in column 1 (handy shortcut for running commands that you don't want logged

On branch update-zshrc-zshaddhistory-pattern
- Changes to be committed:
  -	modified:   home/.zshrc