### PR TITLE
Added zstyle completion to allow tab complete of partial word file name

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -519,6 +519,13 @@ if [ -f $HOME/.zshrc.local ]; then
   source $HOME/.zshrc.local
 fi
 
+# Enable case insensitive tab completion of file names, even from partial words of the file name
+# https://stackoverflow.com/a/22627273/1361782
+zstyle ':completion:*' completer _complete
+zstyle ':completion:*' matcher-list '' 'm:{[:lower:][:upper:]}={[:upper:][:lower:]}' '+l:|=* r:|=*'
+autoload -Uz compinit
+compinit
+
 ### Added by Zinit's installer
 if [[ ! -f $HOME/.zinit/bin/zinit.zsh ]]; then
     print -P "%F{33}▓▒░ %F{220}Installing DHARMA Initiative Plugin Manager (zdharma/zinit)…%f"


### PR DESCRIPTION
`+zstyle ':completion:*' matcher-list '' 'm:{[:lower:][:upper:]}={[:upper:][:lower:]}' '+l:|=* r:|=*'`

On branch add-partial-word-completion-zstyle

- Changes to be committed:
  -	modified:   home/.zshrc