### PR TITLE
Updated sinfo_drained_reason function to print single line per node

### DIFF
--- a/zsh/.zshrc.local.cheaha
+++ b/zsh/.zshrc.local.cheaha
@@ -56,7 +56,10 @@ if [[ "$(hostname -s)" =~ "cheaha-master|login|c[0-9][0-9][0-9][0-9]" ]]; then #
   }
   sinfo_drained_reason () {
     for node in $(sinfo --states=drain --noheader -N | awk '{print $1}' | sort | uniq); do
-      scontrol show node $node | egrep "NodeName|Reason" | sed -E -e 's/Arch.*$|Cores.*$//g'
+      reason=`scontrol show node $node | egrep "NodeName|Reason" | sed -E -e 's/Arch.*$|Cores.*$//g' | tr '\n' '-'`
+      reason="${reason//Reason=/}"
+      reason="${reason//NodeName=/}"
+      echo $reason
     done
   }
   sinfo_drained_reason_mem () {
@@ -119,6 +122,7 @@ if [[ "$(hostname -s)" =~ "cheaha-master" ]]; then
   #module load slurm
 
   # Cheaha-master aliases
+  alias bright_release='cmsh -n -c "main; versioninfo"'
   alias downhosts='cmsh -n -c "device status | grep DOWN"'
   alias ansible_root='sudo /usr/bin/ansible -i ~mhanby/.ansible/hosts'
   alias reboot_computenodes='sudo /usr/bin/ansible -i ~mhanby/.ansible/hosts computenodes -a "/sbin/shutdown
@@ -194,7 +198,9 @@ alias viro='vim -Mn'
 # Open vim without reading .vimrc, much faster (not so be confused with
 # vim.tiny binary, which still sources .vimrc
 alias vimtiny='vim -u NONE'
-
+# shortcuts to lower and upper case strings
+alias tolower="tr '[:upper:]' '[:lower:]'"
+alias toupper="tr '[:lower:]' '[:upper:]'"
 # https://www.cyberciti.biz/tips/bash-aliases-mac-centos-linux-unix.html
 alias mountpretty='mount |column -t'
 alias datepretty='date +"%Y%m%d_%H%M%S"'


### PR DESCRIPTION
Updated a shell function I use to print drained nodes along with the drain reason:

```shell
sinfo_drained_reason () {
  for node in $(sinfo --states=drain --noheader -N | awk '{print $1}' | sort | uniq); do
    reason=`scontrol show node $node | egrep "NodeName|Reason" | sed -E -e 's/Arch.*$|Cores.*$//g' | tr '\n' '-'`
    reason="${reason//Reason=/}"
    reason="${reason//NodeName=/}"
    echo $reason
  done
}
```

Previously, it would print 2 lines per node, node name and reason. The updated version prints a single line with both, making grep filtering a lot easier (i.e. sinfo_drained_reason | grep -v RMA)

Ex:

```shell
> sinfo_drained_reason | grep -i "duplicate"
c0105 -   Duplicate jobid [root@2022-05-10T17:30:12]-
c0108 -   Duplicate jobid [root@2022-05-10T17:30:12]-
c0185 -   Duplicate jobid [root@2022-05-04T16:03:38]-
```