### PR TITLE
Add and Update aliases and functions

### DIFF
--- a/zsh/.zshrc.local
+++ b/zsh/.zshrc.local
@@ -1,7 +1,11 @@
 export EDITOR=`which vim`
 
-function mgrep () {
-  grep $1 ~/.zsh_history_cheaha_master.mhanby
+function m-histgrep () {
+  grep $1 ~/.zsh_history_cheaha_master.mhanby | cut -d ";" -f2-
+}
+
+function histgrep () {
+  grep $1 $HISTFILE | cut -d ";" -f2-
 }
 
 # http://stackoverflow.com/questions/103944/real-time-history-export-amongst-bash-terminal-windows/3055135#3055135
@@ -28,12 +32,15 @@ ihighlight () {
 # Host agnostic alias and functions
 alias histall="history -i 1"
 alias igrep="grep -i"
+alias to-lc="tr '[:upper:]' '[:lower:]'"
 alias rpmarch="rpm -qa --queryformat='%{N}-%{V}-%{R}-.%{arch}\n'"
 alias vmlist="virsh --connect qemu:///system list"
 alias virsh-sys="virsh --connect qemu:///system"
-alias proclist='ps -eo user,pid,ppid,pcpu,pmem,stat,start_time,etime,cmd --sort=-pcpu,-pmem | egrep -v "  0.[0-9]  0.[0-9] "'
+#alias proclist='ps -eo user,pid,ppid,pcpu,pmem,stat,start_time,etime,cmd --sort=-pcpu,-pmem | egrep -v "  0.[0-9]  0.[0-9] "'
+alias proclist='ps -eo user,pid,ppid,pcpu,pmem,stat,start_time,etime,cmd --sort=-pcpu,-pmem | egrep -v "  0.[0-9]  0.[0-9] "| egrep -v "auditbeat|metricbeat|vscode|gnome-shell|firefox|slideshow" | egrep -v " [0-9]  0.[0-9]" | egrep -v "rsync|polkitd|sftp-server|notty|mhanby|screensaver|mmfsd|atom"'
 alias memlist='ps -eo user,pid,ppid,cmd:75,%mem,%cpu --sort=-%mem | head -n 15'
 alias topmem="ps aux --sort=-%mem | awk 'NR<=10{print \$0}'"
+
 function vmlist-remote() { virsh --connect qemu+ssh://$1/system list; }
 function virsh-sys-remote() { virsh --connect qemu+ssh://$1/system; }
 # Sort processes by top virtmem usage
@@ -54,6 +61,7 @@ alias gitdiff='git --no-pager diff'
 # VI Aliases
 # Open file in readonly and no swap
 alias viro='vim -Mn'
+alias vimro='vim -Mn'
 # Open vim without reading .vimrc, much faster (not so be confused with
 # vim.tiny binary, which still sources .vimrc
 alias vimtiny='vim -u NONE'

--- a/zsh/.zshrc.local.cheaha
+++ b/zsh/.zshrc.local.cheaha
@@ -47,6 +47,7 @@ if [[ "$(hostname -s)" =~ "cheaha-master|login|c[0-9][0-9][0-9][0-9]" ]]; then #
   alias scancel_admin="sudo /cm/shared/apps/slurm/current/bin/scancel"
   alias sacctmgr_admin="sudo /cm/shared/apps/slurm/current/bin/sacctmgr"
   alias sinfo_gres='sinfo -o "%15N %10c %10m  %25f %10G"'
+  alias sinfo_clean='sinfo --format "%.10P %.10l %.6D %.6m %N"'
   alias sinfo_downhosts="sinfo --states=down --noheader -N | awk '{print \$1}' | sort | uniq"
   slurm_disable_user () {
     sudo /cm/shared/apps/slurm/current/bin/sacctmgr modify user $1 set maxjobs=0
@@ -175,8 +176,8 @@ function proclog() {
 function serialnum() {
   echo "SFA14k:"
   ssh user@sfa14k1 "show enc al" | grep "Production serial numb"
-  echo "SFA12k:"
-  ssh user@sfa12k1 "show enc al" | grep "Production serial numb"
+  #echo "SFA12k:"
+  #ssh user@sfa12k1 "show enc al" | grep "Production serial numb"
 }
 
 # Fail2ban Aliases


### PR DESCRIPTION
New function `histgrep` to grep from the `$HISTFILE`, also cut's the date from the output. I find this useful as my history file can have 10's of thousands of lines in it, yet I limit the output of `history` to 10K to avoid performance issues with the ZSH prompt

```shell
function histgrep () {
  grep $1 $HISTFILE | cut -d ";" -f2-
}
```

Added an alias `to-lc` to lowercase strings

```shell
alias to-lc="tr '[:upper:]' '[:lower:]'"
```

Updated `proclist` to grep out noisy processes from the list of top CPU/Mem users

```shell
alias proclist='ps -eo user,pid,ppid,pcpu,pmem,stat,start_time,etime,cmd --sort=-pcpu,-pmem | egrep -v "  0.[0-9]  0.[0-9] "| egrep -v "auditbeat|metricbeat|vscode|gnome-shell|firefox|slideshow" | egrep -v " [0-9]  0.[0-9]" | egrep -v "rsync|polkitd|sftp-server|notty|mhanby|screensaver|mmfsd|atom"'
```

Added a duplicate of `viro` as `vimro`, I guess I could just get rid of `viro`...

```shell
alias viro='vim -Mn'
alias vimro='vim -Mn'
```

Added `sinfo_clean` alias for the Slurm `sinfo` command. This alias prints the partition, time limit, number of nodes, memory, and node list. This is different than the default behavior where it prints multiple lines per partition showing idle, mixed, allocated and drained nodes

```shell
alias sinfo_clean='sinfo --format "%.10P %.10l %.6D %.6m %N"'
```