### PR TITLE
Added man page search highlighting vars to zshrc

### DIFF
--- a/zsh/.zshrc.local
+++ b/zsh/.zshrc.local
@@ -86,4 +86,13 @@ if [ -f $HOME/.zshrc.local.cheaha ]; then
   source $HOME/.zshrc.local.cheaha
 fi
 
+## less/man search highlighting
+## https://stackoverflow.com/questions/10535432/tmux-man-page-search-highlighting
+export LESS_TERMCAP_mb=$'\E[01;31m'       # begin blinking
+export LESS_TERMCAP_md=$'\E[01;38;5;74m'  # begin bold
+export LESS_TERMCAP_me=$'\E[0m'           # end mode
+export LESS_TERMCAP_se=$'\E[0m'           # end standout-mode
+export LESS_TERMCAP_so=$'\E[38;5;016m\E[48;5;220m'    # begin standout-mode - info box
+export LESS_TERMCAP_ue=$'\E[0m'           # end underline
+export LESS_TERMCAP_us=$'\E[04;38;5;146m' # begin underline
 

--- a/zsh/.zshrc.local.cheaha
+++ b/zsh/.zshrc.local.cheaha
@@ -47,7 +47,7 @@ if [[ "$(hostname -s)" =~ "cheaha-master|login|c[0-9][0-9][0-9][0-9]" ]]; then #
   alias scancel_admin="sudo /cm/shared/apps/slurm/current/bin/scancel"
   alias sacctmgr_admin="sudo /cm/shared/apps/slurm/current/bin/sacctmgr"
   alias sinfo_gres='sinfo -o "%15N %10c %10m  %25f %10G"'
-  alias sinfo_clean='sinfo --format "%.10P %.10l %.6D %.6m %N"'
+  alias sinfo_clean='sinfo --summarize --all'
   alias sinfo_downhosts="sinfo --states=down --noheader -N | awk '{print \$1}' | sort | uniq"
   slurm_disable_user () {
     sudo /cm/shared/apps/slurm/current/bin/sacctmgr modify user $1 set maxjobs=0


### PR DESCRIPTION
In a `tmux` session, searching within `less` and `man` (which uses `less` as the pager) italisize the resulting matches instead of highlighting them. Hard as hell to find the match. The following fixes this and sets the background behind the match to yellow

https://stackoverflow.com/questions/10535432/tmux-man-page-search-highlighting

```shell
export LESS_TERMCAP_mb=$'\E[01;31m'       # begin blinking
export LESS_TERMCAP_md=$'\E[01;38;5;74m'  # begin bold
export LESS_TERMCAP_me=$'\E[0m'           # end mode
export LESS_TERMCAP_se=$'\E[0m'           # end standout-mode
export LESS_TERMCAP_so=$'\E[38;5;016m\E[48;5;220m'    # begin standout-mode - info box
export LESS_TERMCAP_ue=$'\E[0m'           # end underline
export LESS_TERMCAP_us=$'\E[04;38;5;146m' # begin underline
```

Changed the `sinfo_clean` alias to using the builtin shortcut `--summarize` which produces a nicer output:

```shell
$ sinfo_clean
PARTITION          AVAIL  TIMELIMIT   NODES(A/I/O/T)  NODELIST
interactive           up    2:00:00       30/21/0/51  c[0151-0201]
short                 up   12:00:00       30/21/0/51  c[0151-0201]
...
```