### PR TITLE
Fix TMUX config to use screen-256color

### DIFF
--- a/tmux/.tmux.conf.local
+++ b/tmux/.tmux.conf.local
@@ -456,7 +456,6 @@ set -s escape-time 0
 #   less /var/log/messages
 #   WARNING: terminal is not fully functional
 set -g default-terminal "screen-256color"
-set -ga terminal-overrides ",xterm-256color:Tc"
 
 # Disabling the default setting in https://github.com/gpakosz/.tmux.git .tmux.conf
 set -g renumber-windows off    # don't renumber windows when a window is closed


### PR DESCRIPTION
Fix based on upstream issue https://github.com/gpakosz/.tmux/issues/656

Copying my comments from the issue https://github.com/gpakosz/.tmux/issues/656#issuecomment-1632654772

Some notes on what got me to this issue in case it helps others troubleshoot.

- Hardware: Apple Macbook Pro M1 Ventura
- Terminal: iTerm2 (latest beta) **Terminal** set to `xterm-256color` in my iTerm2 profile
- Remote server: RHEL 7.9

Workflow, I SSH to a remote server and start or attach to Tmux (using this repo's `~/.tmux.conf`). Following the latest `git pull` I started getting odd `TERM` and `DISPLAY` errors when running commands via `sudo`:

Example using `sudo less`:

```shell
$ echo $TERM
tmux-256color

$ sudo less /var/log/messages
WARNING: terminal is not fully functional
/var/log/messages  (press RETURN)
```

Another example when attempting to run Dell's `dsu` command (firmware update tool) against a remote client server to the one where Tmux is running:

```shell
$ sudo ansible c01 -m shell -a '/usr/sbin/dsu -q -u --import-public-key
...
xterm: Xt error: Can't open display: %s
xterm: DISPLAY is not set
...
        648ed6eb-7a13-4d31-9507-77b33108ad97  | 10-07-2023 11:12:18  |  FATAL   |       Inventory file not found - /usr/libexec/dell_dup/inv.xml
```

The solution @gpakosz solved the issue after killing the Tmux session and starting a new one. I did have that in my `~/.tmux.conf.local`, however the line following it was causing problems (since removed):

```diff
diff --git a/tmux/.tmux.conf.local b/tmux/.tmux.conf.local
index 7b865f3..859ecc0 100644
--- a/tmux/.tmux.conf.local
+++ b/tmux/.tmux.conf.local
@@ -456,7 +456,6 @@ set -s escape-time 0
 #   less /var/log/messages
 #   WARNING: terminal is not fully functional
 set -g default-terminal "screen-256color"
-set -ga terminal-overrides ",xterm-256color:Tc"

 # Disabling the default setting in https://github.com/gpakosz/.tmux.git .tmux.conf
 set -g renumber-windows off    # don't renumber windows when a window is closed
```