### PR TITLE
Fix nocomment alias to use sed instead of grep

### DIFF
--- a/zsh/.zshrc.local
+++ b/zsh/.zshrc.local
@@ -78,8 +78,8 @@ alias vimro='vim -Mn'
 # vim.tiny binary, which still sources .vimrc
 alias vimtiny='vim -u NONE'
 
-## grep without comments
-alias nocomment='grep -Ev '\''^(#|$|;)'\'''
+## Exclude blank lines and comments from output
+alias nocomment="sed -Ee '/^[[:space:]]*(#|$|;)/d'"
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   alias md5='md5 -r'

--- a/zsh/.zshrc.local.cheaha
+++ b/zsh/.zshrc.local.cheaha
@@ -46,6 +46,7 @@ if [[ "$(hostname -s)" =~ "cheaha-master|login|c[0-9][0-9][0-9][0-9]" ]]; then #
   alias scontrol_admin="sudo /cm/shared/apps/slurm/current/bin/scontrol"
   alias scancel_admin="sudo /cm/shared/apps/slurm/current/bin/scancel"
   alias sacctmgr_admin="sudo /cm/shared/apps/slurm/current/bin/sacctmgr"
+  alias sinfo_summary="sinfo -o '%.20P %.5a %.10l %.19F %.10z %.20C'"
   alias sinfo_gres='sinfo -o "%15N %10c %10m  %25f %10G"'
   alias sinfo_clean='sinfo --summarize --all'
   alias sinfo_downhosts="sinfo --states=down --noheader -N | awk '{print \$1}' | sort | uniq"
@@ -57,10 +58,8 @@ if [[ "$(hostname -s)" =~ "cheaha-master|login|c[0-9][0-9][0-9][0-9]" ]]; then #
   }
   sinfo_drained_reason () {
     for node in $(sinfo --states=drain --noheader -N | awk '{print $1}' | sort | uniq); do
-      reason=`scontrol show node $node | egrep "NodeName|Reason" | sed -E -e 's/Arch.*$|Cores.*$//g' | tr '\n' '-'`
-      reason="${reason//Reason=/}"
-      reason="${reason//NodeName=/}"
-      echo $reason
+      reason="$(sinfo -o '%t %E' -hn $node)"
+      echo "$node :: $reason"
     done
   }
   sinfo_drained_reason_mem () {
@@ -232,7 +231,6 @@ alias cpuinfo='lscpu'
 ## get GPU ram on desktop / laptop##
 alias gpumeminfo='grep -i --color memory /var/log/Xorg.0.log'
 ## grep without comments
-alias nocomment='grep -Ev '\''^(#|$|;)'\'''
 alias lt='ls -alrt'
 alias tf='tail -f '
 alias psg='ps auxf | grep '


### PR DESCRIPTION
Fixed an issue with `nocomment` alias producing "Binary file (standard input) matches" with certain ASCII files. Originally, I modified the `grep` command to add `-a` _Process a binary file as if it were text; this is equivalent to the --binary-files=text option_.

However, further digging found a more reliable command line using `sed`.

Also did a cleanup of the `sinfo_drained_reason` Slurm function.